### PR TITLE
fix typo in readme and fix task for cmd terminal

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,9 @@
         "label": "flask and hot-reload - no docker-compose",
         "type": "shell",
         "command": "docker run -it --rm -e FLASK_APP=app.py -e FLASK_ENV=development -p 5000:5000 -v ${PWD}:/app --name flaskcontainer flask flask run --host 0.0.0.0",
+        "windows": {
+          "command": "docker run -it --rm -e FLASK_APP=app.py -e FLASK_ENV=development -p 5000:5000 -v ${cwd}:/app --name flaskcontainer flask flask run --host 0.0.0.0"
+        },        
         "problemMatcher": []
       },
       {

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Reading the article is strongly recommended 😉.
 - Run the app with `VSCode Tasks`
 
     ```bash
-    Press simultaniously CTRL + ALT + T and you will get a popup widow were you can choose your option 
+    Press simultaniously CTRL + ALT + T and you will get a popup window were you can choose your option 
     ```
     ![VSCode Task Options](/assets/png/vsCodeTasksOptions.PNG)
 


### PR DESCRIPTION
- fix of typo in readme file  
- tasks instructions worked on bash terminal, now instructions updated for cmd  terminal too